### PR TITLE
Fixes the endpoint to retrieve menu items

### DIFF
--- a/client/http-client.js
+++ b/client/http-client.js
@@ -16,7 +16,7 @@ module.exports = (config) => {
 
     async menus (options) {
       const queryString = getQueryString(options)
-      const path = `menus/web${queryString}`
+      const path = `menus${queryString}`
       return request(path, config)
     }
   }


### PR DESCRIPTION
`/menus/{channel}` isn't supported by li-server. Changing it to `/menus`