### PR TITLE
feat(client): Respect HTTP_PROXY env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ const html = liSDK.document.render(document)
 const liClient = new liSDK.Client({
   url: 'http://localhost:3001', // required
   accessToken: 'my-awesome-token', // required
-  proxy: 'http://path.to.proxy', // optional, uses HttpsProxyAgent (https-proxy-agent)
+  proxy: 'http://path.to.proxy', // optional, uses HttpsProxyAgent (https-proxy-agent) (if not provided, but HTTP_PROXY env variable is there, it will be used the same way)
   agent: new CustomHttpsAgent() // optional, bring your own (node-fetch compatible) agent, this overrides and ignores the `proxy` config
 })
 

--- a/client/http-client.js
+++ b/client/http-client.js
@@ -1,5 +1,6 @@
 const qs = require('qs')
 const fetch = require('node-fetch')
+const HttpsProxyAgent = require('https-proxy-agent')
 
 module.exports = (clientConfig) => {
   // setup proxy agent in case a proxy is configured
@@ -7,8 +8,9 @@ module.exports = (clientConfig) => {
   if (clientConfig.agent) {
     agent = clientConfig.agent
   } else if (clientConfig.proxy) {
-    const HttpsProxyAgent = require('https-proxy-agent')
     agent = new HttpsProxyAgent(clientConfig.proxy)
+  } else if (process.env.HTTP_PROXY) {
+    agent = new HttpsProxyAgent(process.env.HTTP_PROXY)
   } else if (![null, false].includes(clientConfig.agent)) {
     if (/^https/i.test(clientConfig.url)) {
       const https = require('https')


### PR DESCRIPTION
The underlying fetch library [does not respect](https://github.com/bitinn/node-fetch/issues/195) the `HTTP_PROXY` environment variable.

Given that `livingdocs-node-sdk` is not just a fetch client, but an SDK that will most probably be used in enterprise environments, I think it should support this usual convention.

It also simplifies configuration. Without it, there is another configuration layer that is being added for each configuration profile.