### PR TITLE
Add route resolve method

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -43,6 +43,10 @@ module.exports = class Client {
   async getMedia (options) {
     return this.service.mediaLibrary(options)
   }
+
+  async resolvePath (options = {}) {
+    return this.service.routing(options)
+  }
 }
 
 function validateConfig (config) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "mocha --recursive ./test/client/client-test.js"
   },
   "dependencies": {
+    "axios": "^0.21.0",
     "https-proxy-agent": "^2.2.1",
     "lodash": "^4.17.4",
     "node-fetch": "^2.3.0",


### PR DESCRIPTION
## Motivation

We changed the setup of the Livingdocs website to use the Livingdocs routing system. For this we didn't want to talk to the REST API directly, but use the node-sdk.

## Changelog

### 🎁  New method `resolvePath` for node-sdk

You can now call `resolvePath` as follows to get the document behind a path.

```
liClient.resolvePath('/foo/bar')
```

returns:

```
{
  type: 'document',
  resource: {
    id: 123
  }
}
```

or:

```
{
  type: 'redirect',
  path: '/new/bar'
}
```


## Tests

I didn't write any tests. I inspected the current test setup and IMO it's worthless in that manner. I suggest we completely setup a new test framework in a follow-up PR and delete the current one.