### PR TITLE
fix(http-client): properly get project design by version

### DIFF
--- a/client/http-client.js
+++ b/client/http-client.js
@@ -64,8 +64,8 @@ module.exports = (clientConfig) => {
     },
 
     projectDesign (options) {
-      const version = options && `/${options.version}` ? options.version : ''
-      const path = `design${version}`
+      const version = options && options.version
+      const path = `design${version ? `/${version}` : ''}`
       return publicApiRequest(path, config)
     },
 

--- a/test/client/client-test.js
+++ b/test/client/client-test.js
@@ -43,6 +43,12 @@ describe('client', function () {
     expect(client).to.have.property('service')
   })
 
+  describe('project design', function () {
+    it('should exist', function () {
+      expect(client.service).to.have.property('projectDesign')
+    })
+  })
+
   describe('publication', function () {
     it('should exist', function () {
       expect(client.service).to.have.property('latestPublication')


### PR DESCRIPTION
Correctly construct the api client request in case of getting the project design by version, see https://github.com/livingdocsIO/livingdocs-server/blob/master/app/features/public-api/public_api_routes.js#L190